### PR TITLE
fix: adds default file encodings to dockerfile

### DIFF
--- a/Dockerfile-ogc-api-records
+++ b/Dockerfile-ogc-api-records
@@ -2,7 +2,7 @@ FROM openjdk:11-jre
 
 EXPOSE 8080
 
-ENV JAVA_OPTS=
+ENV JAVA_OPTS=-Dfile.encoding=UTF-8
 
 ADD ./modules/services/ogc-api-records/target/gn-ogc-api-records.jar /opt/app/gn-ogc-api-records.jar
 


### PR DESCRIPTION
This PR adds a default encoding to ogc-api-records in order to avoid display errors in responses.