### PR TITLE
Implement custom scripts for ogc-api-records-services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !modules/services/searching/target/searching.jar
 !modules/services/ogc-api-records/target/gn-ogc-api-records.jar
+!docker/

--- a/Dockerfile-ogc-api-records
+++ b/Dockerfile-ogc-api-records
@@ -4,6 +4,9 @@ EXPOSE 8080
 
 ENV JAVA_OPTS=-Dfile.encoding=UTF-8
 
+COPY docker/ /
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+
 ADD ./modules/services/ogc-api-records/target/gn-ogc-api-records.jar /opt/app/gn-ogc-api-records.jar
 
 CMD exec java $JAVA_OPTS -jar /opt/app/gn-ogc-api-records.jar

--- a/docker/docker-entrypoint.d/100-execute-custom-scripts.sh
+++ b/docker/docker-entrypoint.d/100-execute-custom-scripts.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Executing custom scripts located in CUSTOM_SCRIPTS_DIRECTORY if environment variable is set
+if [[ -z "${CUSTOM_SCRIPTS_DIRECTORY}" ]]; then
+  echo "[INFO] No CUSTOM_SCRIPTS_DIRECTORY env variable set"
+else
+  echo "[INFO] CUSTOM_SCRIPTS_DIRECTORY env variable set to ${CUSTOM_SCRIPTS_DIRECTORY}"
+  # Regex is needed in jetty9 images, but not alpine's ones.
+  run-parts -v "${CUSTOM_SCRIPTS_DIRECTORY}" --regex='.*'
+  echo "[INFO] End executing custom scripts"
+fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]
+then
+  # Regex is needed to execute all kind of files, including sh files. Warning : --regex not available in alpine images.
+  /bin/run-parts --verbose "$DIR" --regex='.*'
+fi
+
+exec "$@"


### PR DESCRIPTION
# Custom scripts 

This PR adds the capability to run scripts at startup of the container.

It's a part of the georchestra PR :
- https://github.com/georchestra/georchestra/pull/4083

Soving issue : 
- https://github.com/georchestra/georchestra/issues/4030

## How-to

Set  `CUSTOM_SCRIPTS_DIRECTORY` environment variable to point to a valid volume.
Set a volume with scripts to execute.


Example :
```
 ogc-api-records:
    image: georchestra/gn-cloud-ogc-api-records-service:latest
    ...
    volumes:
      - georchestra_datadir:/etc/georchestra
    environment:
      - CUSTOM_SCRIPTS_DIRECTORY=/etc/georchestra/ogc-api/scripts
```